### PR TITLE
Better finding of the Dropbox location.

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,22 @@
-http://instant.thrift-rpc.org/
+# ACM
 
-is where you can download these things.
+This is the Audio Content Manager project for Literacy Bridge.
 
-instructions:
-1. compile and put binaries in bin/ here.
-2. copy contents of lib/rb/lib to lib/rb/lib here.
-3. sit back & relax.
+## Building and Artifacts
+### Prerequesites
+**Java 7**
+: The project still uses Java 7. Make sure you have it installed.
+
+**Ant**
+: If you don't alread have it, install Apache Ant from http://ant.apache.org.
+
+### Building
+To do everything, simply run
+    ant
+This will clean any old build artifacts, fetch dependencies, build the application, run the tests, and create the distribution package.
+
+## Running
+The simple command line to run the application is
+    java -cp acm.jar:lib/* org.literacybridge.acm.gui.Application <ACM-name>
+(On Windows, use **;** as a path separator, not **:**.)
+

--- a/acm/build.xml
+++ b/acm/build.xml
@@ -6,7 +6,7 @@
   <taskdef resource="net/sf/antcontrib/antlib.xml"
            classpath="${basedir}/ant/ant-contrib-1.0b3.jar"/>
 
-  <target name="dist" depends="clean, jar" description="build, test, and package the project">
+  <target name="dist" depends="clean, jar, test" description="build, test, and package the project">
 	<mkdir dir="${package.dir}"/>
 	<mkdir dir="${package.dir}/lib"/>
 	<mkdir dir="${package.dir}/resources"/>

--- a/acm/ivy.xml
+++ b/acm/ivy.xml
@@ -33,7 +33,10 @@
     <dependency org="com.seaglasslookandfeel" name="seaglasslookandfeel" rev="0.2.0-JAVA8"/>
     <dependency org="org.swinglabs" name="swingx" rev="1.6.1"/>
     <dependency org="args4j" name="args4j" rev="2.0.16"/>
-    <dependency org="commons-io" name="commons-io" rev="2.4"></dependency>
-    <dependency org="net.sf.opencsv" name="opencsv" rev="2.3"></dependency>
+    <dependency org="commons-io" name="commons-io" rev="2.4"/>
+    <dependency org="net.sf.opencsv" name="opencsv" rev="2.3"/>
+    <dependency org="org.powermock" name="powermock-api-mockito" rev="1.6.4" />
+    <dependency org="org.powermock" name="powermock-module-junit4-common" rev="1.6.4" />
+    <dependency org="org.powermock" name="powermock-module-junit4" rev="1.6.4" />
   </dependencies>
 </ivy-module>

--- a/acm/scripts/deploy.sh
+++ b/acm/scripts/deploy.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # Script to deploy everything that makes up the ACM.
+set -eu
+traditionalIFS="$IFS"
+IFS="`printf '\n\t'`"
 
 # Find dropbox.
-if [ -z $dropbox ]; then
+if [ -z ${dropbox-} ]; then
     if [ -e ~/LiteracyBridge/ACM/software/dbfinder.jar ]; then
         dropbox=$(java -jar ~/LiteracyBridge/ACM/software/dbfinder.jar)
     elif [ -e ~/Dropbox\ \(Literacy\ Bridge\) ]; then
-        dropbox=~/Dropbox\ \(Literacy\ Bridge\(
+        dropbox=~/Dropbox\ \(Literacy\ Bridge\)
     elif [ -e ~/Dropbox ]; then
         dropbox=~/Dropbox
     else
@@ -15,6 +18,7 @@ if [ -z $dropbox ]; then
     fi
     export dropbox=$dropbox
 fi
+echo "Dropbox is in $dropbox"
 
 # Convenience shortcuts.
 installDir=$dropbox/LB-software/ACM-install
@@ -61,6 +65,7 @@ echo "dbfinder is in $dbfinder"
 read -p "Press [enter] to continue..."
 
 # Copy the ACM itself.
+set -x
 mkdir -p $acmDir
 cp -r ../build/package/* $acmDir/
 cp acm.bat $acmDir/

--- a/acm/src/main/java/org/literacybridge/acm/Constants.java
+++ b/acm/src/main/java/org/literacybridge/acm/Constants.java
@@ -3,7 +3,7 @@ package org.literacybridge.acm;
 import java.io.File;
 
 public class Constants {
-	public final static String ACM_VERSION					= "r1512150";
+	public final static String ACM_VERSION					= "r1602290";   // yy mm dd n
 	public final static String LiteracybridgeHomeDirName	= "LiteracyBridge";
 	public final static String ACM_DIR_NAME			    	= "ACM";
 	public final static String CACHE_DIR_NAME			    = "cache";

--- a/acm/src/main/java/org/literacybridge/acm/Constants.java
+++ b/acm/src/main/java/org/literacybridge/acm/Constants.java
@@ -7,8 +7,6 @@ public class Constants {
 	public final static String LiteracybridgeHomeDirName	= "LiteracyBridge";
 	public final static String ACM_DIR_NAME			    	= "ACM";
 	public final static String CACHE_DIR_NAME			    = "cache";
-	public final static String DefaultSharedDirName1		= "Dropbox";
-	public final static String DefaultSharedDirName2		= "My Documents/Dropbox";
 	public final static String TempDir 						= "temp";
 	public final static String DBHomeDir 					= "db";
 	public final static String RepositoryHomeDir 			= "content";

--- a/acm/src/main/java/org/literacybridge/acm/audioconverter/converters/A18BaseConverter.java
+++ b/acm/src/main/java/org/literacybridge/acm/audioconverter/converters/A18BaseConverter.java
@@ -53,7 +53,7 @@ public abstract class A18BaseConverter extends BaseAudioConverter {
 				}
 			}
 			
-			if (tmpDir != null && !tmpDir.equals(targetDir) && targetDir.getAbsolutePath().startsWith(ACMConfiguration.getCurrentDB().getSharedACMDirectory().getAbsolutePath())) {
+			if (tmpDir != null && !tmpDir.equals(targetDir) && targetDir.getAbsolutePath().startsWith(ACMConfiguration.getInstance().getCurrentDB().getSharedACMDirectory().getAbsolutePath())) {
 				// targetDir should never be in Dropbox because of some strange interaction with Dropbox that has caused bad A18 output 
 				ultimateDestDir = targetDir;
 				targetDir = tmpDir;

--- a/acm/src/main/java/org/literacybridge/acm/categories/DefaultLiteracyBridgeTaxonomy.java
+++ b/acm/src/main/java/org/literacybridge/acm/categories/DefaultLiteracyBridgeTaxonomy.java
@@ -59,7 +59,7 @@ public class DefaultLiteracyBridgeTaxonomy {
 		TaxonomyRevision taxonomy = loadTaxonomy(DefaultLiteracyBridgeTaxonomy.class.getResourceAsStream("/" + YAML_FILE_NAME));
 
 		// check if there is a newer one in the
-		File acmTaxonomyFile = new File(ACMConfiguration.getCurrentDB().getSharedACMDirectory(), YAML_FILE_NAME);
+		File acmTaxonomyFile = new File(ACMConfiguration.getInstance().getCurrentDB().getSharedACMDirectory(), YAML_FILE_NAME);
 		if (acmTaxonomyFile.exists()) {
 			FileInputStream in = null;
 			try {

--- a/acm/src/main/java/org/literacybridge/acm/config/ACMConfiguration.java
+++ b/acm/src/main/java/org/literacybridge/acm/config/ACMConfiguration.java
@@ -1,12 +1,14 @@
 package org.literacybridge.acm.config;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.literacybridge.acm.Constants;
+import org.literacybridge.acm.categories.Taxonomy;
+import org.literacybridge.acm.gui.CommandLineParams;
+import org.literacybridge.acm.utils.DropboxFinder;
+
+import javax.swing.*;
+import java.io.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -14,46 +16,62 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
-import javax.swing.JFileChooser;
-import javax.swing.JOptionPane;
-
-import org.literacybridge.acm.Constants;
-import org.literacybridge.acm.categories.Taxonomy;
-import org.literacybridge.acm.gui.CommandLineParams;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 public class ACMConfiguration {
-	private static final Logger LOG = Logger.getLogger(ACMConfiguration.class.getName());
-	
-	private static final Map<String, DBConfiguration> allDBs = Maps.newHashMap();
-	private static final AtomicReference<DBConfiguration> currentDB = new AtomicReference<DBConfiguration>();
-	static final File LB_HOME_DIR = new File(Constants.USER_HOME_DIR, Constants.LiteracybridgeHomeDirName);
-	
-    private static String title;
-    private static boolean disableUI = false;
-    private static boolean forceSandbox = false;
-	private static final Properties ACMGlobalConfigProperties = new Properties();
-	private static File globalShareDir;
-	
-	public synchronized static void initialize(CommandLineParams args) {
-		loadProps();
-		
-		if (args.titleACM != null) {
-			title = args.titleACM;
-		}
-		
-		disableUI = args.disableUI;
-		forceSandbox = args.sandbox;
-		
-		setupACMGlobalPaths();
-		
-		for (DBConfiguration config : discoverDBs()) {
-			allDBs.put(config.getSharedACMname(), config);
-			System.out.println("Found DB " + config.getSharedACMname());
-		}
-		
+    private static final Logger LOG = Logger.getLogger(ACMConfiguration.class.getName());
+
+    private  final Map<String, DBConfiguration> allDBs = Maps.newHashMap();
+    private  final AtomicReference<DBConfiguration> currentDB = new AtomicReference<DBConfiguration>();
+    final File LB_HOME_DIR = new File(Constants.USER_HOME_DIR, Constants.LiteracybridgeHomeDirName);
+
+    private  String title;
+    private  boolean disableUI = false;
+    private  boolean forceSandbox = false;
+    private  final Properties ACMGlobalConfigProperties = new Properties();
+    private  File globalShareDir;
+
+    /**
+     * Get the shared instance of the configuration class. Initialize it if not already initialized.
+     *
+     * @return The shared ACMConfiguration instance.
+     */
+    private static ACMConfiguration instance;
+    public synchronized static ACMConfiguration getInstance() {
+        if (instance == null) {
+            CommandLineParams emptyParams = new CommandLineParams();
+            instance = new ACMConfiguration(emptyParams);
+        }
+        return instance;
+    }
+
+    /**
+     * Initialize the shared ACMConfiguration instance. Must not already be initialized.
+     *
+     * @param params ACM Command Line Parameter.
+     */
+    public synchronized static void initialize(CommandLineParams params) {
+        if (instance != null) {
+            throw new IllegalStateException("Attempt to initialize ACMConfiguration after it is already initialized");
+        }
+        instance = new ACMConfiguration(params);
+    }
+
+    private ACMConfiguration(CommandLineParams params) {
+        loadProps();
+
+        if (params.titleACM != null) {
+            title = params.titleACM;
+        }
+
+        disableUI = params.disableUI;
+        forceSandbox = params.sandbox;
+
+        setupACMGlobalPaths();
+
+        for (DBConfiguration config : discoverDBs()) {
+            allDBs.put(config.getSharedACMname(), config);
+            System.out.println("Found DB " + config.getSharedACMname());
+        }
+
         if (!ACMGlobalConfigProperties.containsKey(Constants.USER_NAME)) {
             String username = (String)JOptionPane.showInputDialog(null, "Enter Username:", "Missing Username", JOptionPane.PLAIN_MESSAGE);
             ACMGlobalConfigProperties.put(Constants.USER_NAME, username);
@@ -66,93 +84,91 @@ public class ACMConfiguration {
         }
 
         writeProps();
-	}
+    }
 
-	// TODO: when we have a homescreen this method needs to be split up into different steps,
-	// e.g. close DB, open new DB, etc.
-	public synchronized static void setCurrentDB(String dbName, boolean createEmptyDB) throws Exception {
-		DBConfiguration config = allDBs.get(dbName);
-		if (config == null) {
-			if (!createEmptyDB) {
-				throw new IllegalArgumentException("DB '" + dbName + "' not known.");
-			} else {
-				config = new DBConfiguration(dbName);
-				allDBs.put(dbName, config);
-			}
-		}
-		
-		DBConfiguration oldDB = currentDB.get();
-		if (oldDB != null) {
-			oldDB.getDatabaseConnection().close();
-			Taxonomy.resetTaxonomy(); // necessary 
-			LockACM.unlockFile();
-		}
+    // TODO: when we have a homescreen this method needs to be split up into different steps,
+    // e.g. close DB, open new DB, etc.
+    public synchronized  void setCurrentDB(String dbName, boolean createEmptyDB) throws Exception {
+        DBConfiguration config = allDBs.get(dbName);
+        if (config == null) {
+            if (!createEmptyDB) {
+                throw new IllegalArgumentException("DB '" + dbName + "' not known.");
+            } else {
+                config = new DBConfiguration(dbName);
+                allDBs.put(dbName, config);
+            }
+        }
 
-		config.init(); 
-		
-		System.out.println("Connecting to DB " + config.getSharedACMname());
-		config.connectDB();
-		
-		currentDB.set(config);
-	}
-	
-	public synchronized static void closeCurrentDB() {
-		DBConfiguration oldDB = currentDB.get();
-		if (oldDB != null) {
-			oldDB.getDatabaseConnection().close();
-		}		
-	}
-	
-	public synchronized static DBConfiguration getCurrentDB() {
-		return currentDB.get();
-	}
+        DBConfiguration oldDB = currentDB.get();
+        if (oldDB != null) {
+            oldDB.getDatabaseConnection().close();
+            Taxonomy.resetTaxonomy(); // necessary
+            LockACM.unlockFile();
+        }
 
-	public static File dirACM(String acmName) {
-		File f = null;
-		loadProps();
+        config.init();
 
-		String globalSharePath = ACMGlobalConfigProperties.getProperty(Constants.GLOBAL_SHARE_PATH);
-		if (globalSharePath != null) {
-			f = new File (globalSharePath,acmName + "/" + Constants.TBLoadersHomeDir);
-			if (!f.exists()) {
-				f = null;
-			}
-		} 		
-		return f;		
-	}
-	
-    public static String getUserName() {
+        System.out.println("Connecting to DB " + config.getSharedACMname());
+        config.connectDB();
+
+        currentDB.set(config);
+    }
+
+    public synchronized  void closeCurrentDB() {
+        DBConfiguration oldDB = currentDB.get();
+        if (oldDB != null) {
+            oldDB.getDatabaseConnection().close();
+        }
+    }
+
+    public synchronized  DBConfiguration getCurrentDB() {
+        return currentDB.get();
+    }
+
+    public File dirACM(String acmName) {
+        File f = null;
+
+        if (globalShareDir != null) {
+            f = new File (globalShareDir, acmName + File.separator + Constants.TBLoadersHomeDir);
+            if (!f.exists()) {
+                f = null;
+            }
+        }
+        return f;
+    }
+
+    public String getUserName() {
         return ACMGlobalConfigProperties.getProperty("USER_NAME");
     }
 
-    public static String getUserContact() {
+    public String getUserContact() {
         return ACMGlobalConfigProperties.getProperty(Constants.USER_CONTACT_INFO);
     }
 
-    public static String getRecordingCounter() {
+    public String getRecordingCounter() {
         return ACMGlobalConfigProperties.getProperty(Constants.RECORDING_COUNTER_PROP);
     }
 
-    public static void setRecordingCounter(String counter) {
-    	ACMGlobalConfigProperties.setProperty(Constants.RECORDING_COUNTER_PROP, counter);
-    	ACMConfiguration.writeProps();
+    public void setRecordingCounter(String counter) {
+        ACMGlobalConfigProperties.setProperty(Constants.RECORDING_COUNTER_PROP, counter);
+        writeProps();
     }
 
-    public static String getNewAudioItemUID() throws IOException {
-        String value = ACMConfiguration.getRecordingCounter();
+    public String getNewAudioItemUID() throws IOException {
+        String value = getRecordingCounter();
         int counter = (value == null) ? 0 : Integer.parseInt(value, Character.MAX_RADIX);
         counter++;
         value = Integer.toString(counter, Character.MAX_RADIX);
         String uuid = "LB-2" + "_"  + getDeviceID() + "_" + value;
 
         // make sure we remember that this uuid was already used
-        ACMConfiguration.setRecordingCounter(value);
+        setRecordingCounter(value);
         //writeProps();
 
         return uuid;
     }
 
-    public static String getDeviceID() throws IOException {
+    public String getDeviceID() throws IOException {
         String value = ACMGlobalConfigProperties.getProperty(Constants.DEVICE_ID_PROP);
         if (value == null) {
             final int n = 10;
@@ -170,96 +186,114 @@ public class ACMConfiguration {
         return value;
     }
 
-	
-	private static void setupACMGlobalPaths() {
-		String globalSharePath = ACMGlobalConfigProperties.getProperty(Constants.GLOBAL_SHARE_PATH);
-		if (globalSharePath != null) {
-			globalShareDir = new File (globalSharePath);
-		} 
-		
-		if (globalSharePath == null || globalShareDir == null || !globalShareDir.exists()) {
-			//try default dropbox installation
-			globalShareDir = new File (Constants.USER_HOME_DIR, Constants.DefaultSharedDirName1);
-			if (!globalShareDir.exists()) {
-				globalShareDir = new File (Constants.USER_HOME_DIR, Constants.DefaultSharedDirName2);
-			}
-				
-		}
-		
-		if (!globalShareDir.exists()) {
-			JFileChooser fc = new JFileChooser();
-			fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-			fc.setDialogTitle("Select Dropbox directory.");
-			int returnVal = fc.showOpenDialog(null);
-			if (returnVal == JFileChooser.APPROVE_OPTION) {
-				globalShareDir = fc.getSelectedFile();
-			} else {
-				JOptionPane.showMessageDialog(null,"Dropbox directory has not been identified. Shutting down.");
-				System.exit(0);								
-			}
-		}
-		
-		ACMGlobalConfigProperties.put(Constants.GLOBAL_SHARE_PATH, globalShareDir.getAbsolutePath());
-	}
-	
-	private static List<DBConfiguration> discoverDBs() {
-		List<DBConfiguration> dbs = Lists.newLinkedList();
-		if (getGlobalShareDir().exists()) {
-			File[] dirs = getGlobalShareDir().listFiles(new FileFilter() {
-				@Override public boolean accept(File path) {
-					return path.isDirectory();
-				}
-			});
-			
-			for (File d : dirs) {
-				if (d.exists() && new File(d, Constants.DB_ACCESS_FILENAME).exists()) {
-					dbs.add(new DBConfiguration(d.getName()));
-				}
-			}
-		}
-		return dbs;
-	}
-	
-	public static String getACMname() {
-		return title;
-	}
-	
-	public static boolean isDisableUI() {
-		return disableUI;
-	}
 
-	public static boolean isForceSandbox() {
-		return forceSandbox;
-	}
-	
-	public static File getGlobalShareDir() {
-		return globalShareDir;
-	}
-	
-	private static File getConfigurationPropertiesFile() {
-		return new File(LB_HOME_DIR, Constants.GLOBAL_CONFIG_PROPERTIES);
-	}
-	
-	public static void loadProps() {
-		if (getConfigurationPropertiesFile().exists()) {
-			try {
-				BufferedInputStream in = new BufferedInputStream(new FileInputStream(getConfigurationPropertiesFile()));
-				ACMGlobalConfigProperties.load(in);
-			} catch (IOException e) {
-				throw new RuntimeException("Unable to load configuration file: " + getConfigurationPropertiesFile(), e);
-			}
-		}
-	}
-	
-	public static void writeProps() {
-		try {
-			BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(getConfigurationPropertiesFile()));
-			ACMGlobalConfigProperties.store(out, null);
-			out.flush();
-			out.close();
-		} catch (IOException e) {
-			throw new RuntimeException("Unable to write configuration file: " + getConfigurationPropertiesFile(), e);
-		}
-	}
+    /**
+     * The Global Shared Directory is where all the ACMs an supporting files are kept.
+     * In general, this will be in Dropbox. For testing, it will be different, and it
+     * could be different for some specialized circumstances.
+     *
+     * Side effect: globalShareDir is set to a directory, or the application exits.
+     */
+    private  void setupACMGlobalPaths() {
+        boolean dirUpdated = false;
+        // If there is an environment override for 'dropbox', use that for the global directory.
+        String override = System.getenv("dropbox");
+        if (override != null && override.length() > 0) {
+            globalShareDir = new File(override);
+            LOG.info(String.format("Using override for shared global directory: %s", override));
+        } else {
+            String globalSharePath = ACMGlobalConfigProperties.getProperty(Constants.GLOBAL_SHARE_PATH);
+            if (globalSharePath != null) {
+                globalShareDir = new File(globalSharePath);
+            }
+            // If we didn't find the global directory, try to get it from Dropbox directly.
+            if (globalSharePath == null || globalShareDir == null || !globalShareDir.exists()) {
+                globalSharePath = DropboxFinder.getDropboxPath();
+                globalShareDir = new File(globalSharePath);
+                dirUpdated = true;
+                LOG.info(String.format("Using Dropbox configuration for shared global directory: %s", globalSharePath));
+            }
+            // If we still didn't find the directory, prompt the user.
+            if (!globalShareDir.exists() || !globalShareDir.isDirectory()) {
+                JFileChooser fc = new JFileChooser();
+                fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+                fc.setDialogTitle("Select Dropbox directory.");
+                int returnVal = fc.showOpenDialog(null);
+                if (returnVal == JFileChooser.APPROVE_OPTION) {
+                    globalShareDir = fc.getSelectedFile();
+                    dirUpdated = true;
+                }
+            }
+        }
+        // If we STILL didn't find the global directory, abort.
+        if (globalShareDir == null || !globalShareDir.exists() || !globalShareDir.isDirectory()) {
+            LOG.warning("Unable to find shared global directory. Shutting down");
+            JOptionPane.showMessageDialog(null, "Dropbox directory has not been identified. Shutting down.");
+            System.exit(0);
+        }
+        if (dirUpdated) {
+            ACMGlobalConfigProperties.put(Constants.GLOBAL_SHARE_PATH, globalShareDir.getAbsolutePath());
+        }
+    }
+
+    private  List<DBConfiguration> discoverDBs() {
+        List<DBConfiguration> dbs = Lists.newLinkedList();
+        if (getGlobalShareDir().exists()) {
+            File[] dirs = getGlobalShareDir().listFiles(new FileFilter() {
+                @Override public boolean accept(File path) {
+                    return path.isDirectory();
+                }
+            });
+
+            for (File d : dirs) {
+                if (d.exists() && new File(d, Constants.DB_ACCESS_FILENAME).exists()) {
+                    dbs.add(new DBConfiguration(d.getName()));
+                }
+            }
+        }
+        return dbs;
+    }
+
+    public String getACMname() {
+        return title;
+    }
+
+    public boolean isDisableUI() {
+        return disableUI;
+    }
+
+    public boolean isForceSandbox() {
+        return forceSandbox;
+    }
+
+    public File getGlobalShareDir() {
+        return globalShareDir;
+    }
+
+    private  File getConfigurationPropertiesFile() {
+        return new File(LB_HOME_DIR, Constants.GLOBAL_CONFIG_PROPERTIES);
+    }
+
+    private void loadProps() {
+        if (getConfigurationPropertiesFile().exists()) {
+            try {
+                BufferedInputStream in = new BufferedInputStream(new FileInputStream(getConfigurationPropertiesFile()));
+                ACMGlobalConfigProperties.load(in);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to load configuration file: " + getConfigurationPropertiesFile(), e);
+            }
+        }
+    }
+
+    private void writeProps() {
+        try {
+            BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(getConfigurationPropertiesFile()));
+            ACMGlobalConfigProperties.store(out, null);
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to write configuration file: " + getConfigurationPropertiesFile(), e);
+        }
+    }
 
 }

--- a/acm/src/main/java/org/literacybridge/acm/config/ControlAccess.java
+++ b/acm/src/main/java/org/literacybridge/acm/config/ControlAccess.java
@@ -152,7 +152,7 @@ public class ControlAccess {
 			@SuppressWarnings("unused")
 			LockACM l = new LockACM(config);
 		} catch (RuntimeException e) {
-			if (!ACMConfiguration.getInstance().getInstance().isDisableUI())
+			if (!ACMConfiguration.getInstance().isDisableUI())
 				JOptionPane.showMessageDialog(null, "This ACM is already opened.");
 			else
 				System.out.println("This ACM is already opened!!!");

--- a/acm/src/main/java/org/literacybridge/acm/config/ControlAccess.java
+++ b/acm/src/main/java/org/literacybridge/acm/config/ControlAccess.java
@@ -152,7 +152,7 @@ public class ControlAccess {
 			@SuppressWarnings("unused")
 			LockACM l = new LockACM(config);
 		} catch (RuntimeException e) {
-			if (!ACMConfiguration.isDisableUI())
+			if (!ACMConfiguration.getInstance().getInstance().isDisableUI())
 				JOptionPane.showMessageDialog(null, "This ACM is already opened.");
 			else
 				System.out.println("This ACM is already opened!!!");
@@ -162,12 +162,12 @@ public class ControlAccess {
 			dbInfo = new DBInfo(config);
 		}
 		if (dbInfo.isCheckedOut()) {
-			if (ACMConfiguration.isForceSandbox()) {
+			if (ACMConfiguration.getInstance().isForceSandbox()) {
 				System.out.println("Sandbox mode forced, but DB is currently checked out. Check DB in and restart with sandbox flag.");
 				System.exit(0);
 			}
 			setSandbox(false);
-			if (!ACMConfiguration.isDisableUI()) {
+			if (!ACMConfiguration.getInstance().isDisableUI()) {
 				JOptionPane.showMessageDialog(null,"You have already checked out this ACM.\nYou can now continue making changes to it.");
 			}
 		} else {
@@ -292,11 +292,11 @@ public class ControlAccess {
 			online = false;
 			sandboxMode = true;
 			if (setCurrentFileToLastModified()) {
-				if (!ACMConfiguration.isDisableUI()) {
+				if (!ACMConfiguration.getInstance().isDisableUI()) {
 					JOptionPane.showMessageDialog(null,"Cannot connect to Literacy Bridge server.");
 				}
 			} else {
-				if (!ACMConfiguration.isDisableUI()) {
+				if (!ACMConfiguration.getInstance().isDisableUI()) {
 					JOptionPane.showMessageDialog(null,"Cannot connect to Literacy Bridge server and no available database. Shutting down.");
 				}
 				System.exit(0);
@@ -312,7 +312,7 @@ public class ControlAccess {
 				} catch (IOException e) {
 					dbAvailable = false;
 					Object[] options = {"Try again", "Use Demo Mode"};
-					if (!ACMConfiguration.isDisableUI()) {
+					if (!ACMConfiguration.getInstance().isDisableUI()) {
 						onlineChoice = JOptionPane.showOptionDialog(null, "Cannot reach Literacy Bridge web server.  Do you want to get online now and try again or use Demo Mode?", "Cannot Connect to Server",JOptionPane.YES_NO_CANCEL_OPTION,
 								JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
 					}
@@ -323,7 +323,7 @@ public class ControlAccess {
 			if (dbAvailable && !haveLatestDB()) {
 				if (getCurrentZipFilename() == null) {
 					// no zip exists at all -- must shut down
-					if (!ACMConfiguration.isDisableUI()) {
+					if (!ACMConfiguration.getInstance().isDisableUI()) {
 						JOptionPane.showMessageDialog(null,"There is no copy of this ACM database on this computer.\nIt may be that the database has not been uploaded and downloaded yet.\nShutting down.");
 					}
 					System.exit(0);
@@ -331,7 +331,7 @@ public class ControlAccess {
 					outdatedDB = true;
 				}
 			}
-			if (!userHasWriteAccess() || !dbAvailable || outdatedDB || ACMConfiguration.isForceSandbox()) {
+			if (!userHasWriteAccess() || !dbAvailable || outdatedDB || ACMConfiguration.getInstance().isForceSandbox()) {
 				sandboxMode = true;
 			}
 			if (outdatedDB) {
@@ -340,7 +340,7 @@ public class ControlAccess {
 				dialogMessage = "Another user currently has write access to the ACM.\n";
 				dialogMessage += getPosessor() + "\n";
 			}
-			if (online && sandboxMode && userHasWriteAccess() && !ACMConfiguration.isDisableUI()) {
+			if (online && sandboxMode && userHasWriteAccess() && !ACMConfiguration.getInstance().isDisableUI()) {
 				Object[] optionsNoForce = {"Use Demo Mode", "Shutdown"};
 
 				int n = JOptionPane.showOptionDialog(null, dialogMessage,"Cannot Get Write Access",JOptionPane.YES_NO_CANCEL_OPTION,
@@ -352,7 +352,7 @@ public class ControlAccess {
 			}
 			if (!sandboxMode) {
 				int n = 0;
-				if (!ACMConfiguration.isDisableUI()) {
+				if (!ACMConfiguration.getInstance().isDisableUI()) {
 					if (getCurrentZipFilename().equalsIgnoreCase(DB_DOES_NOT_EXIST)) {
 						JOptionPane.showMessageDialog(null,"ACM does not exist yet. Creating a new ACM and giving you write access.");
 					} else {
@@ -375,7 +375,7 @@ public class ControlAccess {
 						} catch (IOException e) {
 							dbAvailable = false;
 							sandboxMode = true;
-							if (!ACMConfiguration.isDisableUI()) {
+							if (!ACMConfiguration.getInstance().isDisableUI()) {
 								Object[] options = {"Try again", "Use Demo Mode"};
 								onlineChoice = JOptionPane.showOptionDialog(null, "Cannot reach Literacy Bridge web server.  Do you want to get online now and try again or use Demo Mode?", "Cannot Connect to Server",JOptionPane.YES_NO_CANCEL_OPTION,
 										JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
@@ -386,7 +386,7 @@ public class ControlAccess {
 					} while (onlineChoice == 0);
 
 
-					if (!dbAvailable && !sandboxMode && !ACMConfiguration.isDisableUI()) {
+					if (!dbAvailable && !sandboxMode && !ACMConfiguration.getInstance().isDisableUI()) {
 						JOptionPane.showMessageDialog(null,"Sorry, but another user must have just checked out this ACM a moment ago!\nTry contacting " + getPosessor() + "\nAfter clicking OK, the ACM will shutdown.");
 						System.exit(0);
 					} else if (!sandboxMode) {
@@ -399,7 +399,7 @@ public class ControlAccess {
 		}
 		setSandbox(sandboxMode);
 		if (sandboxMode) {
-			if (!ACMConfiguration.isDisableUI()) {
+			if (!ACMConfiguration.getInstance().isDisableUI()) {
 				JOptionPane.showMessageDialog(null,"The ACM is running in demonstration mode.\nPlease remember that your changes will not be saved.");
 			}
 		}
@@ -409,7 +409,7 @@ public class ControlAccess {
 		String writeUser, thisUser;
 		boolean userHasWriteAccess = false;
 
-		thisUser = ACMConfiguration.getUserName().trim();
+		thisUser = ACMConfiguration.getInstance().getUserName().trim();
 		if (thisUser == null) {
 			// No User Name found in config.properties.  Forcing Read-Only mode.
 			return false;
@@ -459,7 +459,7 @@ public class ControlAccess {
 		}
 
 
-		url = new URL("http://literacybridge.org/checkout.php?db=" + db + "&action=" + action + "&name=" + ACMConfiguration.getUserName() + "&contact=" + ACMConfiguration.getUserContact()+ "&version=" + Constants.ACM_VERSION + "&computername=" + computerName);
+		url = new URL("http://literacybridge.org/checkout.php?db=" + db + "&action=" + action + "&name=" + ACMConfiguration.getInstance().getUserName() + "&contact=" + ACMConfiguration.getInstance().getUserContact()+ "&version=" + Constants.ACM_VERSION + "&computername=" + computerName);
 		InputStream in;
 		in = url.openStream();
 		Scanner scanner = new Scanner(in);
@@ -509,7 +509,7 @@ public class ControlAccess {
 			computerName = "UNKNOWN";
 		}
 
-		url = new URL("http://literacybridge.org/checkin.php?db=" + db + "&action=" + action + "&key=" + key + "&filename=" + filename + "&name=" + ACMConfiguration.getUserName() + "&contact=" + ACMConfiguration.getUserContact()+ "&version=" + Constants.ACM_VERSION + "&computername=" + computerName);
+		url = new URL("http://literacybridge.org/checkin.php?db=" + db + "&action=" + action + "&key=" + key + "&filename=" + filename + "&name=" + ACMConfiguration.getInstance().getUserName() + "&contact=" + ACMConfiguration.getInstance().getUserContact()+ "&version=" + Constants.ACM_VERSION + "&computername=" + computerName);
 		InputStream in;
 		in = url.openStream();
 		Scanner scanner = new Scanner(in);
@@ -533,7 +533,7 @@ public class ControlAccess {
 		File inFolder= config.getDatabaseDirectory();
 		File outFile= new File (config.getSharedACMDirectory(), getNextZipFilename());
 		int n;
-		if (!ACMConfiguration.isDisableUI()) {
+		if (!ACMConfiguration.getInstance().isDisableUI()) {
 			Object[] optionsSaveWork = {"Save Work", "Throw Away Your Latest Changes"};
 			n = JOptionPane.showOptionDialog(null, "If you made a mistake you can throw away all your changes now.", "Save Work?",JOptionPane.YES_NO_CANCEL_OPTION,
 					JOptionPane.QUESTION_MESSAGE, null, optionsSaveWork, optionsSaveWork[0]);
@@ -554,7 +554,7 @@ public class ControlAccess {
 					ZipUnzip.zip(inFolder, outFile);
 				} catch (IOException e) {
 					status = false;
-					if (!ACMConfiguration.isDisableUI()) {
+					if (!ACMConfiguration.getInstance().isDisableUI()) {
 						Object[] options = {"Keep Your Changes", "Throw Away Your Latest Changes"};
 						n = JOptionPane.showOptionDialog(null, "There is a problem getting your changes into Dropbox.  Do you want to keep your changes and try to get this problem fixed or throw away your latest changes?", "Problem creating zip file on Dropbox",JOptionPane.YES_NO_CANCEL_OPTION,
 								JOptionPane.WARNING_MESSAGE, null, options, options[0]);
@@ -569,7 +569,7 @@ public class ControlAccess {
 			}
 			try {
 				status = checkInDB(config.getSharedACMname(), key, filename);
-				if (!status && saveWork && !ACMConfiguration.isDisableUI()) {
+				if (!status && saveWork && !ACMConfiguration.getInstance().isDisableUI()) {
 					//Object[] options = {"Force your version","Throw Away Your Latest Changes"};
 					JOptionPane.showMessageDialog(null, "Someone has forced control of this ACM, so you cannot check-in your changes.\nIf you are worried about losing a lot of work, contact Cliff and he may be able to save you and your work.");
 					saveWork = false;  // zip is alredy written to dropbox an could be recovered.  !saveWork & status will delete checkoutfile marker but not any zips.
@@ -580,7 +580,7 @@ public class ControlAccess {
 				}
 			} catch (IOException e) {
 				status = false;
-				if (!ACMConfiguration.isDisableUI()) {
+				if (!ACMConfiguration.getInstance().isDisableUI()) {
 					Object[] options = {"Try again", "Shutdown"};
 					n = JOptionPane.showOptionDialog(null, "Cannot reach Literacy Bridge web server.\nDo you want to get online and try again or shutdown and try later?", "Cannot Connect to Server",JOptionPane.YES_NO_CANCEL_OPTION,
 							JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
@@ -588,7 +588,7 @@ public class ControlAccess {
 			}
 		}
 
-		if (!ACMConfiguration.isDisableUI()) {
+		if (!ACMConfiguration.getInstance().isDisableUI()) {
 			if (status && saveWork)
 				JOptionPane.showMessageDialog(null,"Your changes have been checked in.\n\nPlease stay online for a few minutes so your changes\ncan be uploaded (until Dropbox is 'Up to date').");
 			else if (saveWork && !status)

--- a/acm/src/main/java/org/literacybridge/acm/config/DBConfiguration.java
+++ b/acm/src/main/java/org/literacybridge/acm/config/DBConfiguration.java
@@ -90,7 +90,7 @@ public class DBConfiguration extends Properties {
     }
 
     public static File getLiteracyBridgeHomeDir() {
-        return ACMConfiguration.LB_HOME_DIR;
+        return ACMConfiguration.getInstance().LB_HOME_DIR;
     }
 
     public File getLuceneIndexDirectory() {
@@ -191,7 +191,7 @@ public class DBConfiguration extends Properties {
 
     public File getSharedACMDirectory() {
         if (sharedACMDirectory == null) {
-            sharedACMDirectory = new File(ACMConfiguration.getGlobalShareDir(), getSharedACMname());
+            sharedACMDirectory = new File(ACMConfiguration.getInstance().getGlobalShareDir(), getSharedACMname());
         }
         return sharedACMDirectory;
     }
@@ -345,7 +345,7 @@ public class DBConfiguration extends Properties {
 
 
         if (getSharedACMname() != null && (getDatabaseDirectory() == null || getRepositoryDirectory() == null)) {
-            File fACM = new File(ACMConfiguration.getGlobalShareDir(), getSharedACMname());
+            File fACM = new File(ACMConfiguration.getInstance().getGlobalShareDir(), getSharedACMname());
             if (fACM.exists()) {
                 /*				File fDB = new File(fACM,Constants.DBHomeDir);
 				setDatabaseDirectory(fDB);

--- a/acm/src/main/java/org/literacybridge/acm/core/DataRequestService.java
+++ b/acm/src/main/java/org/literacybridge/acm/core/DataRequestService.java
@@ -105,7 +105,7 @@ public class DataRequestService implements IDataRequestService {
 	}
 
 	private AudioItemIndex getAudioItemIndex() {
-		DBConfiguration db = ACMConfiguration.getCurrentDB();
+		DBConfiguration db = ACMConfiguration.getInstance().getCurrentDB();
 		if (db != null) {
 			return db.getAudioItemIndex();
 		}

--- a/acm/src/main/java/org/literacybridge/acm/db/Persistence.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/Persistence.java
@@ -155,10 +155,10 @@ public class Persistence {
             }
         }
 
-        DBConfiguration config = ACMConfiguration.getCurrentDB();
+        DBConfiguration config = ACMConfiguration.getInstance().getCurrentDB();
         AudioItemCache cache = null;
         if (config != null) {
-            cache = ACMConfiguration.getCurrentDB().getAudioItemCache();
+            cache = ACMConfiguration.getInstance().getCurrentDB().getAudioItemCache();
         }
 
         for (AudioItem audioItem : AudioItem.getFromDatabase()) {

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentAudioItem.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentAudioItem.java
@@ -162,7 +162,7 @@ public class PersistentAudioItem extends PersistentObject {
 
     @Override
     protected void afterCommitHook() {
-    	DBConfiguration db = ACMConfiguration.getCurrentDB();
+    	DBConfiguration db = ACMConfiguration.getInstance().getCurrentDB();
     	if (db != null) {
 	    	AudioItemIndex index = db.getAudioItemIndex();
 	    	if (index != null) {
@@ -189,7 +189,7 @@ public class PersistentAudioItem extends PersistentObject {
     }
 
     public static PersistentAudioItem getFromDatabase(String uuid) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         PersistentAudioItem result = null;
         try {
             Query findObject = em.createQuery("SELECT o FROM PersistentAudioItem o WHERE o.uuid = '" + uuid + "'");

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentAudioItemStatistic.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentAudioItemStatistic.java
@@ -145,7 +145,7 @@ public class PersistentAudioItemStatistic extends PersistentObject {
     }
     
     public static PersistentAudioItemStatistic getFromDatabase(String deviceId) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         PersistentAudioItemStatistic result = null;
         try {
             Query findObject = em.createQuery("SELECT o FROM PersistentAudioItemStatistic o WHERE o.device_id = '" + deviceId + "'");

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentCategory.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentCategory.java
@@ -160,7 +160,7 @@ public class PersistentCategory extends PersistentObject {
     }
     
     public static PersistentCategory getFromDatabase(String uuid) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         PersistentCategory result = null;
         try {
             Query findObject = em.createQuery("SELECT o FROM PersistentCategory o WHERE o.uuid = '" + uuid + "'");

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentLocalizedAudioItem.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentLocalizedAudioItem.java
@@ -111,7 +111,7 @@ public class PersistentLocalizedAudioItem extends PersistentObject {
     }
     
     public static PersistentLocalizedAudioItem getFromDatabase(String uuid) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         PersistentLocalizedAudioItem result = null;
         try {
             Query findObject = em.createQuery("SELECT o FROM PersistentLocalizedAudioItem o WHERE o.uuid = '" + uuid + "'");

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentObject.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentObject.java
@@ -33,7 +33,7 @@ public abstract class PersistentObject implements Serializable, Persistable {
         EntityManager em = null;
 
         try {
-            em = ACMConfiguration.getCurrentDB().getEntityManager();
+            em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
             EntityTransaction t = null;
             try {
                 t = em.getTransaction();
@@ -78,7 +78,7 @@ public abstract class PersistentObject implements Serializable, Persistable {
         EntityManager em = null;
 
         try {
-            em = ACMConfiguration.getCurrentDB().getEntityManager();
+            em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
             EntityTransaction t = null;
             try {
                 t = em.getTransaction();

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentQueries.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentQueries.java
@@ -15,7 +15,7 @@ import org.literacybridge.acm.config.ACMConfiguration;
 class PersistentQueries {
     
 	static <T> T getPersistentObject(Class<T> objectClass, Object id) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         T persistentObject = null;
         try {
             persistentObject = em.find(objectClass, id);
@@ -27,7 +27,7 @@ class PersistentQueries {
     
     @SuppressWarnings("unchecked")
 	static <T> List<T> getPersistentObjects(Class<T> objectClass) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         List<T> results = null;
         try {
             Query findObjects = em.createQuery("SELECT o FROM " + objectClass.getSimpleName() + " o");
@@ -41,7 +41,7 @@ class PersistentQueries {
     
     @SuppressWarnings("unchecked")
 	static List<PersistentAudioItem> searchForAudioItems(String filter, List<PersistentCategory> categories, List<PersistentLocale> locales) {    	
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         List<PersistentAudioItem> searchResults = new LinkedList<PersistentAudioItem>();
         try {
         	// queries all audioitems
@@ -91,7 +91,7 @@ class PersistentQueries {
 
     @SuppressWarnings("unchecked")
 	static List<PersistentAudioItem> searchForAudioItems(String filter, PersistentTag selectedTag) {    	
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         List<PersistentAudioItem> searchResults = new LinkedList<PersistentAudioItem>();
         try {
         	// queries all audioitems
@@ -176,7 +176,7 @@ class PersistentQueries {
     
     @SuppressWarnings("unchecked")
 	static Map<Integer, Integer> getCategoryFacetCounts(String filter, List<PersistentCategory> categories, List<PersistentLocale> locales) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         Map<Integer, Integer> results = new HashMap<Integer, Integer>();
         try {
         	StringBuilder query = new StringBuilder("SELECT DISTINCT t5.id AS \"id\", COUNT(t4.category) AS \"count\" "
@@ -245,7 +245,7 @@ class PersistentQueries {
     
     @SuppressWarnings("unchecked")
 	static Map<String, Integer> getLanguageFacetCounts(String filter, List<PersistentCategory> categories, List<PersistentLocale> locales) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         Map<String, Integer> results = new HashMap<String, Integer>();
         try {
         	StringBuilder query = new StringBuilder("SELECT a.\"lang_id\" AS \"id\", COUNT(a.\"lang_id\") AS \"count\" FROM ("

--- a/acm/src/main/java/org/literacybridge/acm/db/PersistentTag.java
+++ b/acm/src/main/java/org/literacybridge/acm/db/PersistentTag.java
@@ -92,7 +92,7 @@ public class PersistentTag extends PersistentObject {
     }
     
     public static PersistentTag getFromDatabase(String uuid) {
-        EntityManager em = ACMConfiguration.getCurrentDB().getEntityManager();
+        EntityManager em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
         PersistentTag result = null;
         try {
             Query findObject = em.createQuery("SELECT o FROM PersistentTag o WHERE o.uuid = '" + uuid + "'");

--- a/acm/src/main/java/org/literacybridge/acm/gui/Application.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/Application.java
@@ -88,9 +88,9 @@ public class Application extends JXFrame {
             @Override
             public void windowClosing(WindowEvent e) {
                 try {
-                    if (!ACMConfiguration.getCurrentDB().getControlAccess().isSandbox())
-                        ACMConfiguration.getCurrentDB().getControlAccess().updateDB();
-                    ACMConfiguration.closeCurrentDB();
+                    if (!ACMConfiguration.getInstance().getCurrentDB().getControlAccess().isSandbox())
+                        ACMConfiguration.getInstance().getCurrentDB().getControlAccess().updateDB();
+                    ACMConfiguration.getInstance().closeCurrentDB();
                 }
                 catch(Exception e1) {
                     e1.printStackTrace();
@@ -100,15 +100,15 @@ public class Application extends JXFrame {
 
         String title = new String(LabelProvider.getLabel("TITLE_LITERACYBRIDGE_ACM", LanguageUtil.getUILanguage()));
         title += " (" + Constants.ACM_VERSION + ")";
-        if (ACMConfiguration.getACMname() != null)
-            title += "                   " + ACMConfiguration.getACMname();
-        else if (ACMConfiguration.getCurrentDB().getSharedACMname() != null)
-            title += "                   " + ACMConfiguration.getCurrentDB().getSharedACMname();
-        String dbVersion = ACMConfiguration.getCurrentDB().getControlAccess().getCurrentZipFilename();
+        if (ACMConfiguration.getInstance().getACMname() != null)
+            title += "                   " + ACMConfiguration.getInstance().getACMname();
+        else if (ACMConfiguration.getInstance().getCurrentDB().getSharedACMname() != null)
+            title += "                   " + ACMConfiguration.getInstance().getCurrentDB().getSharedACMname();
+        String dbVersion = ACMConfiguration.getInstance().getCurrentDB().getControlAccess().getCurrentZipFilename();
         dbVersion = dbVersion.replaceAll("db", "");
         dbVersion = dbVersion.replaceAll(".zip", "");
         title += " (v" + dbVersion + ")";
-        if (ACMConfiguration.getCurrentDB().getControlAccess().isSandbox())
+        if (ACMConfiguration.getInstance().getCurrentDB().getControlAccess().isSandbox())
             title += "               CHANGES WILL *NOT* BE SAVED!   ";
 
         setTitle(title);
@@ -126,7 +126,7 @@ public class Application extends JXFrame {
             splashScreen.setProgressLabel("Updating index...");
             System.out.print("Building index...");
             long start = System.currentTimeMillis();
-            final AudioItemIndex index = ACMConfiguration.getCurrentDB().loadAudioItemIndex();
+            final AudioItemIndex index = ACMConfiguration.getInstance().getCurrentDB().loadAudioItemIndex();
             if (index != null) {
                 Runtime.getRuntime().addShutdownHook(new Thread() {
                     @Override public void run() {
@@ -242,7 +242,7 @@ public class Application extends JXFrame {
         try {
             // TODO: when we have a homescreen this call will be delayed until the user selects a DB
             // TODO: createEmtpyDB should be factored out when the UI has a create DB button.
-            ACMConfiguration.setCurrentDB(params.sharedACM, true);
+            ACMConfiguration.getInstance().setCurrentDB(params.sharedACM, true);
 
             // DB migration if necessary
             System.out.print("Updating database ... ");
@@ -269,7 +269,7 @@ public class Application extends JXFrame {
 
             LOG.log(Level.INFO, "ACM successfully started.");
             WavCaching caching = new WavCaching();
-            GCInfo gcInfo = ACMConfiguration.getCurrentDB().getRepository().needsGc();
+            GCInfo gcInfo = ACMConfiguration.getInstance().getCurrentDB().getRepository().needsGc();
 
             if (gcInfo.isGcRecommended()) {
                 long sizeMB = gcInfo.getCurrentSizeInBytes() / 1024 / 1024;
@@ -281,11 +281,11 @@ public class Application extends JXFrame {
                             + " java command contains the argument -XMX512m (or more).");
 
                     if (answer == JOptionPane.YES_OPTION) {
-                        ACMConfiguration.getCurrentDB().getRepository().gc();
+                        ACMConfiguration.getInstance().getCurrentDB().getRepository().gc();
                     }
                 }
             }
-            if (ACMConfiguration.getCurrentDB().shouldPreCacheWav()) {
+            if (ACMConfiguration.getInstance().getCurrentDB().shouldPreCacheWav()) {
             	caching.cacheNewA18Files();
             }
         }

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/CategoryView.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/CategoryView.java
@@ -372,7 +372,7 @@ public class CategoryView extends ACMContainer implements Observer {
 	}
 
 	private void createLanguageList() {
-		List<Locale> audioLanguages = ACMConfiguration.getCurrentDB().getAudioLanguages();
+		List<Locale> audioLanguages = ACMConfiguration.getInstance().getCurrentDB().getAudioLanguages();
 		for (Locale locale : audioLanguages) {
 			languagesList.add(new LanguageLabel(locale));
 		}

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/TagsListPopupMenu.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/TagsListPopupMenu.java
@@ -119,7 +119,7 @@ public class TagsListPopupMenu extends JPopupMenu {
 		exportTag.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
-				File listDirectory = new File(ACMConfiguration.getCurrentDB()
+				File listDirectory = new File(ACMConfiguration.getInstance().getCurrentDB()
 						.getTBLoadersDirectory(),
 						"TB_Options/activeLists");
 				LinkedHashMap<String, PersistentCategory> categories = new LinkedHashMap();
@@ -134,7 +134,7 @@ public class TagsListPopupMenu extends JPopupMenu {
 						previousPackageName = packageName;
 						//TODO: need to accommodate multiple message lists (or profiles) in a single package/image
 						//TODO: each new message list would be numbered
-						File dir = new File(ACMConfiguration.getCurrentDB().getTBLoadersDirectory(), "packages/"
+						File dir = new File(ACMConfiguration.getInstance().getCurrentDB().getTBLoadersDirectory(), "packages/"
 								+ packageName + "/messages/lists/" + TBBuilder.firstMessageListName);
 						if (!dir.exists()) {
 							dir.mkdirs();

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/ToolbarView.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/ToolbarView.java
@@ -272,7 +272,7 @@ public class ToolbarView extends JToolBar implements ActionListener
 			// convert on the fly if necessary
 			Application parent = Application.getApplication();
 			parent.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));				
-			File f = ACMConfiguration.getCurrentDB().getRepository()
+			File f = ACMConfiguration.getInstance().getCurrentDB().getRepository()
 							.convert(item.getParentAudioItem(), AudioFormat.WAV);
 			parent.setCursor(Cursor.getDefaultCursor());
 			Application.getFilterState().updateResult();	

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/TreeTransferHandler.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/TreeTransferHandler.java
@@ -145,7 +145,7 @@ public class TreeTransferHandler extends TransferHandler {
 
 				EntityManager em = null;
 				try {
-					em = ACMConfiguration.getCurrentDB().getEntityManager();
+					em = ACMConfiguration.getInstance().getCurrentDB().getEntityManager();
 					EntityTransaction transaction = em.getTransaction();
 					transaction.begin();
 					try {

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/audioItems/AudioItemTableModel.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/audioItems/AudioItemTableModel.java
@@ -154,7 +154,7 @@ public class AudioItemTableModel extends AbstractTableModel {
 				}
 */
 				case DATE_FILE_MODIFIED: {
-					File file = ACMConfiguration.getCurrentDB().getRepository().getAudioFile(audioItem, AudioFormat.A18);
+					File file = ACMConfiguration.getInstance().getCurrentDB().getRepository().getAudioFile(audioItem, AudioFormat.A18);
 					if (file != null) {
 						Date date = new Date(file.lastModified());
 						cellText = dateFormat.format(date);

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/audioItems/AudioItemView.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/audioItems/AudioItemView.java
@@ -80,7 +80,7 @@ public class AudioItemView extends Container implements Observer {
 		audioItemTable.setTransferHandler(new AudioItemTransferHandler());
 
 		// use fixed color; there seems to be a bug in some plaf implementations that cause strange rendering
-		if (ACMConfiguration.getCurrentDB().getControlAccess().isSandbox()) {
+		if (ACMConfiguration.getInstance().getCurrentDB().getControlAccess().isSandbox()) {
 			audioItemTable.addHighlighter(HighlighterFactory.createAlternateStriping(
 					Color.LIGHT_GRAY, new Color(237, 243, 254)));
 		} else  {
@@ -123,7 +123,7 @@ public class AudioItemView extends Container implements Observer {
 	public void update(Observable o, Object arg) {
 		if (arg instanceof IDataRequestResult) {
 			currResult = (IDataRequestResult) arg;
-			updateTable(new AudioItemTableModel(currResult, ACMConfiguration.getCurrentDB().getAudioItemCache()));
+			updateTable(new AudioItemTableModel(currResult, ACMConfiguration.getInstance().getCurrentDB().getAudioItemCache()));
 		}
 
 		if (arg instanceof UILanguageChanged) {
@@ -356,7 +356,7 @@ public class AudioItemView extends Container implements Observer {
 
 	// Special handlers
 	public void setData(IDataRequestResult result) {
-		updateTable(new AudioItemTableModel(result, ACMConfiguration.getCurrentDB().getAudioItemCache()));
+		updateTable(new AudioItemTableModel(result, ACMConfiguration.getInstance().getCurrentDB().getAudioItemCache()));
 		mouseListener.setCurrentResult(result);
 	}
 

--- a/acm/src/main/java/org/literacybridge/acm/gui/dialogs/AudioItemContextMenuDialog.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/dialogs/AudioItemContextMenuDialog.java
@@ -100,8 +100,8 @@ public class AudioItemContextMenuDialog extends JDialog implements WindowListene
 							try {
 								a.destroy();
 								// it's okay to delete from DB but cannot delete the .a18 file since that's in the shared (dropbox) repository
-								if (!ACMConfiguration.getCurrentDB().getControlAccess().isSandbox())
-									ACMConfiguration.getCurrentDB().getRepository().delete(a);
+								if (!ACMConfiguration.getInstance().getCurrentDB().getControlAccess().isSandbox())
+									ACMConfiguration.getInstance().getCurrentDB().getRepository().delete(a);
 							} catch (Exception e) {
 								LOG.log(Level.WARNING, "Unable to delete audioitem id=" + a.getUuid(), e);
 							}

--- a/acm/src/main/java/org/literacybridge/acm/gui/dialogs/audioItemPropertiesDialog/AudioItemPropertiesModel.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/dialogs/audioItemPropertiesDialog/AudioItemPropertiesModel.java
@@ -170,7 +170,7 @@ public class AudioItemPropertiesModel extends AbstractTableModel {
 			}
 
 			@Override public String getValue(AudioItem audioItem) {
-				File file = ACMConfiguration.getCurrentDB().getRepository().getAudioFile(audioItem, AudioFormat.A18);
+				File file = ACMConfiguration.getInstance().getCurrentDB().getRepository().getAudioFile(audioItem, AudioFormat.A18);
 				return file != null ? file.getName() : null;
 			}
 

--- a/acm/src/main/java/org/literacybridge/acm/gui/dialogs/audioItemPropertiesDialog/LanguageComboBoxModel.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/dialogs/audioItemPropertiesDialog/LanguageComboBoxModel.java
@@ -13,7 +13,7 @@ public class LanguageComboBoxModel extends DefaultComboBoxModel {
 	private Object selectedItem;
 	
 	public LanguageComboBoxModel() {
-		supportedLanguages = ACMConfiguration.getCurrentDB().getAudioLanguages();
+		supportedLanguages = ACMConfiguration.getInstance().getCurrentDB().getAudioLanguages();
 	}
 
 	@Override

--- a/acm/src/main/java/org/literacybridge/acm/gui/util/language/LanguageUtil.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/util/language/LanguageUtil.java
@@ -48,7 +48,7 @@ public class LanguageUtil {
 	}
 	
 	public static String getLocalizedLanguageName(Locale locale) {
-		String label = ACMConfiguration.getCurrentDB().getLanguageLabel(locale);
+		String label = ACMConfiguration.getInstance().getCurrentDB().getLanguageLabel(locale);
 		if (label == null) {
 			label = locale.getDisplayLanguage(getUILanguage());
 		}

--- a/acm/src/main/java/org/literacybridge/acm/importexport/A18DeviceExporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/A18DeviceExporter.java
@@ -24,7 +24,7 @@ public class A18DeviceExporter {
 			return false;
 		}
 
-		AudioItemRepository repository = ACMConfiguration.getCurrentDB().getRepository();
+		AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB().getRepository();
 		try {
 			repository.exportA18WithMetadata(item.getParentAudioItem(), deviceLocation);
 		} catch (ConversionException e) {

--- a/acm/src/main/java/org/literacybridge/acm/importexport/A18Importer.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/A18Importer.java
@@ -54,7 +54,7 @@ public class A18Importer extends Importer {
 			
 			if (metadata.getNumberOfFields() == 0) {
 				// legacy mode
-				audioItem = new AudioItem(ACMConfiguration.getNewAudioItemUID());
+				audioItem = new AudioItem(ACMConfiguration.getInstance().getNewAudioItemUID());
 				String fileName = file.getName();
 				metadata.setMetadataField(MetadataSpecification.DTB_REVISION, new MetadataValue<String>("1"));
 				metadata.setMetadataField(MetadataSpecification.DC_IDENTIFIER, new MetadataValue<String>(audioItem.getUuid()));
@@ -109,7 +109,7 @@ public class A18Importer extends Importer {
 				return;
 			}
 			
-			AudioItemRepository repository = ACMConfiguration.getCurrentDB().getRepository();
+			AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB().getRepository();
 			repository.storeAudioFile(audioItem, file);
 			
 			audioItem.commit();

--- a/acm/src/main/java/org/literacybridge/acm/importexport/CSVExporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/CSVExporter.java
@@ -30,7 +30,7 @@ public class CSVExporter {
 	}
 
 	public static void export(Iterable<LocalizedAudioItem> audioItems, File targetFile) throws IOException {
-		String project = ACMConfiguration.getCurrentDB().getSharedACMname();
+		String project = ACMConfiguration.getInstance().getCurrentDB().getSharedACMname();
 		if (project.toLowerCase().startsWith("acm-")) {
 			project = project.substring(4);
 		}

--- a/acm/src/main/java/org/literacybridge/acm/importexport/FileImporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/FileImporter.java
@@ -79,7 +79,7 @@ public class FileImporter {
 			
 			if (item != null) {
 				try {
-					ACMConfiguration.getCurrentDB().getRepository().updateAudioItem(item, file);
+					ACMConfiguration.getInstance().getCurrentDB().getRepository().updateAudioItem(item, file);
 					// Commenting line below since duration is set with updateDuration as called from storeAudioFile()
 					// item.getLocalizedAudioItem(null).getMetadata().setMetadataField(MetadataSpecification.LB_DURATION, new MetadataValue<String>(""));
 					item.commit();

--- a/acm/src/main/java/org/literacybridge/acm/importexport/FileSystemExporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/FileSystemExporter.java
@@ -18,7 +18,7 @@ public class FileSystemExporter {
 		throws IOException {
 		
 		try {
-			AudioItemRepository repository = ACMConfiguration.getCurrentDB().getRepository();
+			AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB().getRepository();
 			
 			for (LocalizedAudioItem localizedAudioItem : selectedAudioItems) {				
 				// first: check which formats we have

--- a/acm/src/main/java/org/literacybridge/acm/importexport/MP3Importer.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/MP3Importer.java
@@ -29,7 +29,7 @@ public class MP3Importer extends Importer {
 			MusicMetadataSet musicMetadataSet = new MyID3().read(file);
 			IMusicMetadata musicMetadata = musicMetadataSet.getSimplified();
 			
-			AudioItem audioItem = new AudioItem(ACMConfiguration.getNewAudioItemUID());
+			AudioItem audioItem = new AudioItem(ACMConfiguration.getInstance().getNewAudioItemUID());
 			audioItem.addCategory(category);
 
 			LocalizedAudioItem localizedAudioItem = new LocalizedAudioItem(audioItem.getUuid() + "-en", Locale.ENGLISH);
@@ -51,7 +51,7 @@ public class MP3Importer extends Importer {
 			metadata.setMetadataField(MetadataSpecification.DC_LANGUAGE, 
 					new MetadataValue<RFC3066LanguageCode>(new RFC3066LanguageCode(Locale.ENGLISH.getLanguage())));
 			
-			AudioItemRepository repository = ACMConfiguration.getCurrentDB().getRepository();
+			AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB().getRepository();
 			repository.storeAudioFile(audioItem, file);			
 			
 			audioItem.commit();

--- a/acm/src/main/java/org/literacybridge/acm/importexport/WAVImporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/importexport/WAVImporter.java
@@ -22,7 +22,7 @@ public class WAVImporter extends Importer {
 	@Override
 	protected void importSingleFile(Category category, File file) throws IOException {
 		try {
-			AudioItem audioItem = new AudioItem(ACMConfiguration.getNewAudioItemUID());
+			AudioItem audioItem = new AudioItem(ACMConfiguration.getInstance().getNewAudioItemUID());
 			audioItem.addCategory(category);
 
 			LocalizedAudioItem localizedAudioItem = new LocalizedAudioItem(audioItem.getUuid() + "-en", Locale.ENGLISH);
@@ -36,7 +36,7 @@ public class WAVImporter extends Importer {
 			metadata.setMetadataField(MetadataSpecification.DC_LANGUAGE, 
 					new MetadataValue<RFC3066LanguageCode>(new RFC3066LanguageCode(Locale.ENGLISH.getLanguage())));
 			
-			AudioItemRepository repository = ACMConfiguration.getCurrentDB().getRepository();
+			AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB().getRepository();
 			repository.storeAudioFile(audioItem, file);			
 
 			audioItem.commit();			

--- a/acm/src/main/java/org/literacybridge/acm/repository/A18DurationUtil.java
+++ b/acm/src/main/java/org/literacybridge/acm/repository/A18DurationUtil.java
@@ -15,7 +15,7 @@ import org.literacybridge.acm.utils.IOUtils;
 
 public class A18DurationUtil {
 	public static void updateDuration(AudioItem audioItem) throws IOException {		
-    	File f = ACMConfiguration.getCurrentDB().getRepository().getAudioFile(audioItem, AudioFormat.A18);
+    	File f = ACMConfiguration.getInstance().getCurrentDB().getRepository().getAudioFile(audioItem, AudioFormat.A18);
     	if (f != null) {
 	    	DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(f)));
 	    	in.skipBytes(4);

--- a/acm/src/main/java/org/literacybridge/acm/repository/WavCaching.java
+++ b/acm/src/main/java/org/literacybridge/acm/repository/WavCaching.java
@@ -29,7 +29,7 @@ public class WavCaching {
 
     private void findUncachedWaveFiles() {
         System.out.print("Finding uncached wave files...");
-        AudioItemRepository repository = ACMConfiguration.getCurrentDB()
+        AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB()
                 .getRepository();
 
         for (AudioItem audioItem : AudioItem.getFromDatabase()) {
@@ -57,7 +57,7 @@ public class WavCaching {
                 try {
                     itemBeingProcessed = item.getUuid();
                     System.out.println("Converting " + itemBeingProcessed);
-                    ACMConfiguration.getCurrentDB().getRepository()
+                    ACMConfiguration.getInstance().getCurrentDB().getRepository()
                     .convert(item, AudioFormat.WAV);
                 } catch (ConversionException e) {
                     e.printStackTrace();

--- a/acm/src/main/java/org/literacybridge/acm/tbbuilder/TBBuilder.java
+++ b/acm/src/main/java/org/literacybridge/acm/tbbuilder/TBBuilder.java
@@ -218,7 +218,7 @@ public class TBBuilder {
 	}
 
 	public TBBuilder (String sharedACM) throws Exception {
-		dropboxTbLoadersDir = ACMConfiguration.dirACM(sharedACM);  //.getCurrentDB().getTBLoadersDirectory();
+		dropboxTbLoadersDir = ACMConfiguration.getInstance().dirACM(sharedACM);  //.getCurrentDB().getTBLoadersDirectory();
 		project = sharedACM.substring(ACM_PREFIX.length());
 		File localTbLoadersDir = new File(DBConfiguration.getLiteracyBridgeHomeDir(), Constants.TBLoadersHomeDir);
 		targetTempDir = new File(localTbLoadersDir,project);
@@ -457,7 +457,7 @@ public class TBBuilder {
 		csvColumns[1] = contentPackage.toUpperCase();
 		csvColumns[3] = list.getName().substring(0, list.getName().length() - 4); // strip .txt
 
-		AudioItemRepository repository = ACMConfiguration.getCurrentDB().getRepository();
+		AudioItemRepository repository = ACMConfiguration.getInstance().getCurrentDB().getRepository();
 		BufferedReader reader = new BufferedReader(new FileReader(list));
 
 		int order = 1;

--- a/acm/src/main/java/org/literacybridge/acm/tbbuilder/TBBuilderUI.java
+++ b/acm/src/main/java/org/literacybridge/acm/tbbuilder/TBBuilderUI.java
@@ -44,7 +44,7 @@ public class TBBuilderUI extends JFrame implements ActionListener {
 
 	private void fillProjectList(JComboBox l) {
 		l.addItem("Select Project");
-		dropbox = new File(Constants.USER_HOME_DIR,Constants.DefaultSharedDirName1);
+		dropbox = ACMConfiguration.getInstance().getGlobalShareDir();
 		// TODO: should be tied into ACMConfiguration.discoverDBs() -- but this means refactoring ACM init to not be DB-specific at first
 		if (dropbox.exists()) {
 			File[] dirs = dropbox.listFiles(new FileFilter() {
@@ -95,7 +95,7 @@ public class TBBuilderUI extends JFrame implements ActionListener {
 		addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosing(WindowEvent e) {
-					ACMConfiguration.closeCurrentDB();
+					ACMConfiguration.getInstance().closeCurrentDB();
 			}
 		});
 
@@ -251,7 +251,7 @@ public class TBBuilderUI extends JFrame implements ActionListener {
 						} 
 					} else {
 						try {
-							ACMConfiguration.setCurrentDB(TBBuilder.ACM_PREFIX + projectList.getSelectedItem().toString(), false);
+							ACMConfiguration.getInstance().setCurrentDB(TBBuilder.ACM_PREFIX + projectList.getSelectedItem().toString(), false);
 						} catch (Exception e1) {
 							// TODO Auto-generated catch block
 							e1.printStackTrace();

--- a/acm/src/main/java/org/literacybridge/acm/tbloader/TBLoader.java
+++ b/acm/src/main/java/org/literacybridge/acm/tbloader/TBLoader.java
@@ -488,14 +488,13 @@ public class TBLoader extends JFrame implements ActionListener {
 			f.mkdirs();
 			TBLoader.tempCollectionFile = f;
 
-			String dropboxPath = System.getProperty("user.home") + "/Dropbox";
-			File dropboxFile = new File(dropboxPath);
-			if (!dropboxFile.exists()) {
-				JOptionPane.showMessageDialog(null, dropboxPath + " does not exist; cannot find the Dropbox path. Please contact ICT staff.",
+			File dropboxDir = ACMConfiguration.getInstance().getGlobalShareDir();
+			if (!dropboxDir.exists()) {
+				JOptionPane.showMessageDialog(null, dropboxDir.getAbsolutePath() + " does not exist; cannot find the Dropbox path. Please contact ICT staff.",
 		                "Cannot Find Dropbox!", JOptionPane.DEFAULT_OPTION);
 				System.exit(ERROR);
 			}
-			File collectedDataFile = new File(dropboxFile,TBLoader.COLLECTED_DATA_DROPBOXDIR_PREFIX + TBLoader.deviceID);
+			File collectedDataFile = new File(dropboxDir,TBLoader.COLLECTED_DATA_DROPBOXDIR_PREFIX + TBLoader.deviceID);
 			if (!collectedDataFile.exists()) {
 				JOptionPane.showMessageDialog(null, collectedDataFile.getAbsolutePath() + " does not exist; cannot find the Dropbox collected data path. Please contact ICT staff.",
 		                "Cannot Find Dropbox Collected Data Folder!", JOptionPane.DEFAULT_OPTION);

--- a/acm/src/main/java/org/literacybridge/acm/tools/DBExporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/tools/DBExporter.java
@@ -41,7 +41,7 @@ public class DBExporter {
             Application.startUp(params);
             DBExporter.hasACMStarted = true;
         } else
-            ACMConfiguration.setCurrentDB(dbName, false);
+            ACMConfiguration.getInstance().setCurrentDB(dbName, false);
         project = dbName.substring(TBBuilder.ACM_PREFIX.length());
     }
 
@@ -72,7 +72,7 @@ public class DBExporter {
             CSVWriter writer = new CSVWriter(new FileWriter(exportFile), ',');
         //String[] header = {"ID","Name","Project"};
             writer.writeNext(header);
-            List <Locale> languages = ACMConfiguration.getCurrentDB().getAudioLanguages();
+            List <Locale> languages = ACMConfiguration.getInstance().getCurrentDB().getAudioLanguages();
             for (Locale l:languages) {
                 String languageCode = l.getLanguage();
                 String languageLabel = LanguageUtil.getLocalizedLanguageName(l);

--- a/acm/src/main/java/org/literacybridge/acm/utils/CmdLineImporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/utils/CmdLineImporter.java
@@ -68,7 +68,7 @@ public class CmdLineImporter {
 			System.exit(2);
 		}
 
-		if (ACMConfiguration.getCurrentDB().getControlAccess().isSandbox()) {
+		if (ACMConfiguration.getInstance().getCurrentDB().getControlAccess().isSandbox()) {
 			System.err.println("Unable to acquire writer access.");
 			System.exit(3);
 		}
@@ -81,7 +81,7 @@ public class CmdLineImporter {
 			System.out.println("At least one file could not be imported.");
 		}
 
-		ACMConfiguration.getCurrentDB().getControlAccess().updateDB();
+		ACMConfiguration.getInstance().getCurrentDB().getControlAccess().updateDB();
 		System.exit(success ? 0 : 4);
 	}
 

--- a/acm/src/main/java/org/literacybridge/acm/utils/DropboxFinder.java
+++ b/acm/src/main/java/org/literacybridge/acm/utils/DropboxFinder.java
@@ -1,0 +1,129 @@
+package org.literacybridge.acm.utils;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+/**
+ * Created by bill on 2/24/16.
+ */
+public class DropboxFinder {
+    private static class BadEnvironmentException extends RuntimeException {
+        BadEnvironmentException(String envVar) {
+            super("Bad environment: missing variable "+envVar);
+        }
+    }
+
+    private static final String infoFileName = "info.json";
+
+
+    public static void main( String[] args ) {
+        String dropboxPath = getDropboxPath();
+        System.out.println( dropboxPath );
+    }
+
+
+    public static String getDropboxPath() {
+        DropboxFinder dbFinder = new DropboxFinder();
+        File infoJson = dbFinder.getInfoFile();
+        return dbFinder.getDropboxPathFromInfoFile(infoJson);
+    }
+
+    /**
+     * Determine if running on Windows.
+     * @return True if running on Windows. False otherwise.
+     */
+    protected boolean onWindows() {
+        String os = System.getProperty("os.name");
+        return os.startsWith("Windows");
+    }
+
+    /**
+     * Reads the "path" property from the info.json file.
+     * @param infoJson A File that may point to an info.json file (it may not exist).
+     * @return The path to the Dropbox data, as a String.
+     */
+    private String getDropboxPathFromInfoFile(File infoJson) {
+        try {
+            InputStream is = new FileInputStream(infoJson);
+            return getDropboxPathFromInputStream(is);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    /**
+     * Parse the Dropbox info.json data, and return the path to the Dropbox.
+     * @param is An input stream that will supply the characters of the JSON.
+     * @return The 'path' property from the JSON file, or empty if none.
+     */
+    protected String getDropboxPathFromInputStream(InputStream is) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(is);
+            JsonNode node = root.get("business");
+            if (node != null) {
+                return node.get("path").getTextValue();
+            }
+            // No business, look for "personal"
+            node = root.get("personal");
+            if (node != null) {
+                return node.get("path").getTextValue();
+            }
+        } catch (Exception ignored) {
+        }
+        return "";
+    }
+
+    /**
+     * Look for Dropbox info.json file. The location is system dependent.
+     * @return File with path to Dropbox info.json. The file may not exist.
+     */
+    protected File getInfoFile() {
+        File infoJson;
+        if (onWindows()) {
+            infoJson = getInfoFileFromWindows();
+        } else {
+            infoJson = getInfoFileFromNix();
+        }
+        return infoJson;
+    }
+
+    /**
+     * Look for Dropbox info.json on Windows system.
+     * @return File with path to Dropbox info.json.
+     */
+    private File getInfoFileFromWindows() {
+        File jsonFile;
+        String jsonPath = System.getenv("APPDATA");
+        if (jsonPath == null) {
+            throw new BadEnvironmentException("APPDATA");
+        }
+        jsonPath = jsonPath + File.separator + "Dropbox";
+        jsonFile = new File(jsonPath, infoFileName);
+        if (!jsonFile.exists()) {
+            jsonPath = System.getenv("LOCALAPPDATA");
+            if (jsonPath == null) {
+                throw new BadEnvironmentException("LOCALAPPDATA");
+            }
+            jsonPath = jsonPath + File.separator + "Dropbox";
+            jsonFile = new File(jsonPath, infoFileName);
+        }
+        return jsonFile;
+    }
+
+    /**
+     * Look for the Dropbox info.json on *nix system (OS/X or Linux).
+     * @return File with path to Dropbox info.json file.
+     */
+    private File getInfoFileFromNix() {
+        File jsonFile;
+        String jsonPath = System.getProperty("user.home");
+        jsonPath = jsonPath + File.separator + ".dropbox";
+        jsonFile = new File(jsonPath, infoFileName);
+        return jsonFile;
+    }
+}

--- a/acm/src/main/java/org/literacybridge/acm/utils/DropboxFinder.java
+++ b/acm/src/main/java/org/literacybridge/acm/utils/DropboxFinder.java
@@ -34,11 +34,14 @@ public class DropboxFinder {
 
     /**
      * Determine if running on Windows.
+     *
+     * This is implemented as a static function so that it can be mocked, for testing. All we really want is
+     * the value of OSChecker.WINDOWS.
+     *
      * @return True if running on Windows. False otherwise.
      */
-    protected boolean onWindows() {
-        String os = System.getProperty("os.name");
-        return os.startsWith("Windows");
+    protected static boolean onWindows() {
+        return OSChecker.WINDOWS;
     }
 
     /**
@@ -84,7 +87,7 @@ public class DropboxFinder {
      */
     protected File getInfoFile() {
         File infoJson;
-        if (onWindows()) {
+        if (DropboxFinder.onWindows()) {
             infoJson = getInfoFileFromWindows();
         } else {
             infoJson = getInfoFileFromNix();

--- a/acm/src/test/java/org/literacybridge/acm/utils/DropboxFinderTest.java
+++ b/acm/src/test/java/org/literacybridge/acm/utils/DropboxFinderTest.java
@@ -1,0 +1,178 @@
+package org.literacybridge.acm.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit test for simple DropboxFinder.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( {DropboxFinderTest.class, DropboxFinder.class })
+public class DropboxFinderTest
+{
+
+    /**
+     * Rigourous Test :-)
+     */
+    @Test
+    public void testDetectWindows()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        PowerMockito.mockStatic(System.class);
+        PowerMockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        assertTrue(dbFinder.onWindows());
+    }
+
+    @Test
+    public void testDetectOSx()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        PowerMockito.mockStatic(System.class);
+        PowerMockito.when(System.getProperty("os.name")).thenReturn("Mac OSX");
+        assertFalse(dbFinder.onWindows());
+    }
+
+    @Test
+    public void testMissingEnvironment()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        PowerMockito.mockStatic(System.class);
+        // Pretend we're on Windows
+        PowerMockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        PowerMockito.when(System.getenv("APPDATA")).thenReturn(null);
+        PowerMockito.when(System.getenv("LOCALAPPDATA")).thenReturn(null);
+
+        boolean gotException = false;
+        File path = null;
+        try {
+            path = dbFinder.getInfoFile();
+        } catch (RuntimeException e) {
+            gotException = true;
+        }
+        assertTrue(gotException);
+    }
+
+
+    @Test
+    public void testGetInfoFilePathForNix()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        PowerMockito.mockStatic(System.class);
+        // Pretend we're on Mac
+        PowerMockito.when(System.getProperty("os.name")).thenReturn("Mac OSX");
+        PowerMockito.when(System.getProperty("user.home")).thenReturn("/home/LB");
+
+        // If, by mistake, we think we're on Windows, we'll use LOCALAPPDATA to find the path:
+        PowerMockito.when(System.getenv("APPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Roaming");
+        PowerMockito.when(System.getenv("LOCALAPPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Local");
+
+        File infoFile = dbFinder.getInfoFile();
+        String expected = "/home/LB" + File.separator + ".dropbox" + File.separator + "info.json";
+        assertEquals(expected, infoFile.getPath());
+    }
+
+    @Test
+    public void testGetInfoFilePathForWindows()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        PowerMockito.mockStatic(System.class);
+        // Pretend we're on Windows
+        PowerMockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        PowerMockito.when(System.getenv("APPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Roaming");
+        PowerMockito.when(System.getenv("LOCALAPPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Local");
+
+        // If, by mistake, we think we're on OS/X or Linux, we'll use this to find the path:
+        PowerMockito.when(System.getProperty("user.home")).thenReturn("/home/LB");
+
+        File infoFile = dbFinder.getInfoFile();
+        String expected = "r:\\Users\\LB\\AppData\\Local" + File.separator + "Dropbox" + File.separator + "info.json";
+        System.out.printf("Expecting %s\ngot%s\n", expected, infoFile.getPath());
+        assertEquals(expected, infoFile.getPath());
+    }
+
+    @Test
+    public void testParseDrobpoxPersonal()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        //String jsonString = "{\"business\": {\"path\": \"/Users/bill/Dropbox (Literacy Bridge)\", \"host\": 4929547026}}";
+        String jsonString = "{\"personal\": {\"path\": \"/Users/LB/Dropbox\", \"host\": 4929547026}}";
+        InputStream jsonStream = null;
+        try {
+            jsonStream = new ByteArrayInputStream(jsonString.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            assertTrue(false); // fail the test.
+        }
+
+        String path;
+        path = dbFinder.getDropboxPathFromInputStream(jsonStream);
+
+        assertEquals("/Users/LB/Dropbox", path);
+    }
+
+    @Test
+    public void testParseDrobpoxBusiness()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        String jsonString = "{\"business\": {\"path\": \"/Users/LB/Dropbox (Literacy Bridge)\", \"host\": 4929547026}}";
+        //String jsonString = "{\"personal\": {\"path\": \"/Users/LB/Dropbox\", \"host\": 4929547026}}";
+        InputStream jsonStream = null;
+        try {
+            jsonStream = new ByteArrayInputStream(jsonString.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            assertTrue(false); // fail the test.
+        }
+
+        String path;
+        path = dbFinder.getDropboxPathFromInputStream(jsonStream);
+
+        assertEquals("/Users/LB/Dropbox (Literacy Bridge)", path);
+    }
+
+    @Test
+    public void testParseDrobpoxBoth()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        String jsonString = "{\"business\": {\"path\": \"/Users/LB/Dropbox (Literacy Bridge)\", \"host\": 4929547026}," +
+                "\"personal\": {\"path\": \"/Users/LB/Dropbox\", \"host\": 4929547026}}";
+        InputStream jsonStream = null;
+        try {
+            jsonStream = new ByteArrayInputStream(jsonString.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            assertTrue(false); // fail the test.
+        }
+
+        String path;
+        path = dbFinder.getDropboxPathFromInputStream(jsonStream);
+
+        assertEquals("/Users/LB/Dropbox (Literacy Bridge)", path);
+    }
+
+    @Test
+    public void testParseBadJson()
+    {
+        DropboxFinder dbFinder = new DropboxFinder();
+        String jsonString = "This is not a JSON string";
+        InputStream jsonStream = null;
+        try {
+            jsonStream = new ByteArrayInputStream(jsonString.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            assertTrue(false); // fail the test.
+        }
+
+        String path;
+        path = dbFinder.getDropboxPathFromInputStream(jsonStream);
+
+        assertEquals("", path);
+    }
+
+}

--- a/acm/src/test/java/org/literacybridge/acm/utils/DropboxFinderTest.java
+++ b/acm/src/test/java/org/literacybridge/acm/utils/DropboxFinderTest.java
@@ -27,19 +27,21 @@ public class DropboxFinderTest
     @Test
     public void testDetectWindows()
     {
+        PowerMockito.mockStatic(DropboxFinder.class);
+        PowerMockito.when(DropboxFinder.onWindows()).thenReturn(true);
+
         DropboxFinder dbFinder = new DropboxFinder();
-        PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getProperty("os.name")).thenReturn("Windows");
-        assertTrue(dbFinder.onWindows());
+        assertTrue(DropboxFinder.onWindows());
     }
 
     @Test
     public void testDetectOSx()
     {
+        PowerMockito.mockStatic(DropboxFinder.class);
+        PowerMockito.when(DropboxFinder.onWindows()).thenReturn(false);
+
         DropboxFinder dbFinder = new DropboxFinder();
-        PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getProperty("os.name")).thenReturn("Mac OSX");
-        assertFalse(dbFinder.onWindows());
+        assertFalse(DropboxFinder.onWindows());
     }
 
     @Test
@@ -51,6 +53,8 @@ public class DropboxFinderTest
         PowerMockito.when(System.getProperty("os.name")).thenReturn("Windows");
         PowerMockito.when(System.getenv("APPDATA")).thenReturn(null);
         PowerMockito.when(System.getenv("LOCALAPPDATA")).thenReturn(null);
+        PowerMockito.mockStatic(DropboxFinder.class);
+        PowerMockito.when(DropboxFinder.onWindows()).thenReturn(true);
 
         boolean gotException = false;
         File path = null;
@@ -71,6 +75,8 @@ public class DropboxFinderTest
         // Pretend we're on Mac
         PowerMockito.when(System.getProperty("os.name")).thenReturn("Mac OSX");
         PowerMockito.when(System.getProperty("user.home")).thenReturn("/home/LB");
+        PowerMockito.mockStatic(DropboxFinder.class);
+        PowerMockito.when(DropboxFinder.onWindows()).thenReturn(false);
 
         // If, by mistake, we think we're on Windows, we'll use LOCALAPPDATA to find the path:
         PowerMockito.when(System.getenv("APPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Roaming");
@@ -90,6 +96,8 @@ public class DropboxFinderTest
         PowerMockito.when(System.getProperty("os.name")).thenReturn("Windows");
         PowerMockito.when(System.getenv("APPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Roaming");
         PowerMockito.when(System.getenv("LOCALAPPDATA")).thenReturn("r:\\Users\\LB\\AppData\\Local");
+        PowerMockito.mockStatic(DropboxFinder.class);
+        PowerMockito.when(DropboxFinder.onWindows()).thenReturn(true);
 
         // If, by mistake, we think we're on OS/X or Linux, we'll use this to find the path:
         PowerMockito.when(System.getProperty("user.home")).thenReturn("/home/LB");


### PR DESCRIPTION
With this change we now use the Dropbox configuration to find the user's Dropbox installation.
Additionally, one can use the environment variable 'dropbox' to set up a temporary override,
useful for testing.

Dropbox is used as the "global shared directory", and is part of the ACMConfiguration. To simplify
setting up the configuration, it was converted from a collection of static properties to a
singleton shared instance; adding the 'getInstance()' calls is the bulk of the lines changed
(though the least interesting part).

The actual Dropbox finding code is added in utils/DropboxFinder.java, as well as unit tests for that
new code.

With junit and mockito/powermock integrated into the project, it will be easier for future
commits to also include unit tests. They will now be expected :)