### PR TITLE
Remove unused options from CommandLineParams.java

### DIFF
--- a/acm/src/main/java/org/literacybridge/acm/gui/CommandLineParams.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/CommandLineParams.java
@@ -4,28 +4,15 @@ import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.Argument;
 
 public class CommandLineParams {
-	@Option(name="-r",usage="to force read-only")
-	public boolean readonly;
+    @Option(name="-s",usage="to enter sandbox mode")
+    public boolean sandbox;
 
-	@Option(name="-s",usage="to enter sandbox mode")
-	public boolean sandbox;
+    @Option(name="-title",usage="to set name of ACM to be displayed in title bar")
+    public String titleACM;
 
-	/*	NOT CURRENTLY USING THIS PARAMETER --  NEED TO RETHINK IT WHEN WE NEED IT
-	@Option(name="-db",usage="to set path to database")
-	public String pathDB;
+    @Option(name="-no_ui",usage="start the system without showing the UI")
+    public boolean disableUI;
 
-	@Option(name="-repo",usage="to set path to repository of a18 files")
-	public String pathRepository;
-*/
-	@Option(name="-title",usage="to set name of ACM to be displayed in title bar")
-	public String titleACM;
-
-	@Option(name="-no_ui",usage="start the system without showing the UI")
-	public boolean disableUI;
-
-	@Option(name="-no_index",usage="start the system without building a Lucene index")
-	public boolean disableIndex;
-
-	@Argument
-	public String sharedACM;
+    @Argument
+    public String sharedACM;
 }

--- a/acm/src/main/java/org/literacybridge/acm/tbbuilder/TBBuilder.java
+++ b/acm/src/main/java/org/literacybridge/acm/tbbuilder/TBBuilder.java
@@ -213,9 +213,7 @@ public class TBBuilder {
     public TBBuilder (String sharedACM, boolean isCreate) throws Exception {
         CommandLineParams params = new CommandLineParams();
         params.disableUI = true;
-        params.readonly = true;
         params.sandbox = true;
-        params.disableIndex = true;
         params.sharedACM = sharedACM;
         if (isCreate) {
             // Creation needs the database, and the application.

--- a/acm/src/main/java/org/literacybridge/acm/tools/CSVDatabaseExporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/tools/CSVDatabaseExporter.java
@@ -12,9 +12,7 @@ public class CSVDatabaseExporter {
     private CSVDatabaseExporter(String acmName) throws Exception {
         CommandLineParams params = new CommandLineParams();
         params.disableUI = true;
-        params.readonly = true;
         params.sandbox = true;
-        params.disableIndex = true;
         params.sharedACM = acmName;
         Application.startUp(params);
     }

--- a/acm/src/main/java/org/literacybridge/acm/tools/DBExporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/tools/DBExporter.java
@@ -28,9 +28,7 @@ public class DBExporter {
             CommandLineParams params = new CommandLineParams();
             params.sharedACM = dbName;
             params.disableUI = true;
-            params.readonly = true;
             params.sandbox = true;
-            params.disableIndex = true;
             Application.startUp(params);
             DBExporter.hasACMStarted = true;
         } else

--- a/acm/src/main/java/org/literacybridge/acm/utils/CmdLineImporter.java
+++ b/acm/src/main/java/org/literacybridge/acm/utils/CmdLineImporter.java
@@ -58,9 +58,6 @@ public class CmdLineImporter {
         try {
             CommandLineParams acmParams = new CommandLineParams();
             acmParams.disableUI = true;
-            //acmParams.readonly = false;
-            //acmParams.sandbox = false;
-            acmParams.disableIndex = true;
             acmParams.sharedACM = params.acmName;
             Application.startUp(acmParams);
         } catch (Exception e) {


### PR DESCRIPTION
This is just a small change that removes the two options "-r" (read-only) and "-no_index" from CommandLineParams. These options are not used anymore anywhere in the ACM.