### PR TITLE
Fix NullPointerException during ACM startup

### DIFF
--- a/acm/src/main/java/org/literacybridge/acm/Constants.java
+++ b/acm/src/main/java/org/literacybridge/acm/Constants.java
@@ -3,7 +3,7 @@ package org.literacybridge.acm;
 import java.io.File;
 
 public class Constants {
-    public final static String ACM_VERSION                  = "r1604080";   // yy mm dd n
+    public final static String ACM_VERSION                  = "r1604290";   // yy mm dd n
     public final static String LiteracybridgeHomeDirName	= "LiteracyBridge";
 	public final static String ACM_DIR_NAME			    	= "ACM";
 	public final static String CACHE_DIR_NAME			    = "cache";

--- a/acm/src/main/java/org/literacybridge/acm/store/AudioItemIndex.java
+++ b/acm/src/main/java/org/literacybridge/acm/store/AudioItemIndex.java
@@ -316,15 +316,7 @@ public class AudioItemIndex {
                         String uuid = term.utf8ToString();
                         Playlist.Builder playlist = playlists.get(uuid);
                         if (playlist != null) {
-                            PostingsEnum tp = leafReader.postings(new Term(PLAYLISTS_FIELD, term), PostingsEnum.PAYLOADS);
-                            while (tp.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                                // TODO: we could also use the termPosition instead of a payload to store the playlist position
-                                tp.nextPosition();
-                                BytesRef payload = tp.getPayload();
-                                int playlistPos = PayloadHelper.decodeInt(payload.bytes, payload.offset);
-                                AudioItem audioItem = loadAudioItem(leafReader.document(tp.docID()));
-                                playlist.addAudioItem(audioItem.getUuid(), playlistPos);
-                            }
+                            loadPlaylistFromPostingList(leafReader, uuid, playlist);
                         }
                     }
                 }
@@ -360,23 +352,30 @@ public class AudioItemIndex {
 
             IndexReader reader = searcher.getIndexReader();
             for (LeafReaderContext leaf : reader.leaves()) {
-                LeafReader leafReader = leaf.reader();
-                PostingsEnum tp = leafReader.postings(new Term(PLAYLISTS_FIELD, uuid), PostingsEnum.PAYLOADS);
-                if (tp != null) {
-                    while (tp.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                        // TODO: we could also use the termPosition instead of a payload to store the playlist position
-                        tp.nextPosition();
-                        BytesRef payload = tp.getPayload();
-                        int playlistPos = PayloadHelper.decodeInt(payload.bytes, payload.offset);
-                        AudioItem audioItem = loadAudioItem(leafReader.document(tp.docID()));
-                        builder.addAudioItem(audioItem.getUuid(), playlistPos);
-                    }
-                }
+                loadPlaylistFromPostingList(leaf.reader(), uuid, builder);
             }
 
             return builder.build();
         } finally {
             searcherManager.release(searcher);
+        }
+    }
+
+    private void loadPlaylistFromPostingList(LeafReader leafReader, String playlistUuid, Playlist.Builder playlistBuilder) throws IOException {
+        // Iterate over the posting list that contains a posting for each AudioItem belonging to the given Playlist
+        PostingsEnum postingsEnum = leafReader.postings(new Term(PLAYLISTS_FIELD, playlistUuid), PostingsEnum.PAYLOADS);
+        if (postingsEnum != null) {
+            while (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                // important: Lucene applies deletes of documents to posting lists lazily when it
+                // performs a segment merge, so it is necessary here to check if this audioItem is deleted
+                if (leafReader.getLiveDocs() == null || leafReader.getLiveDocs().get(postingsEnum.docID())) {
+                    postingsEnum.nextPosition();
+                    BytesRef payload = postingsEnum.getPayload();
+                    int playlistPos = PayloadHelper.decodeInt(payload.bytes, payload.offset);
+                    AudioItem audioItem = loadAudioItem(leafReader.document(postingsEnum.docID()));
+                    playlistBuilder.addAudioItem(audioItem.getUuid(), playlistPos);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
It can happen that the ACM doesn't startup due to a NullPointerException. It only happens when all of the following conditions are true:
- One or more AudioItems were deleted that were part of a Playlist
- The Playlist in question was not deleted
- Lucene didn't yet merge the index segments that stored the deleted AudioItem(s)

There is an easy fix on the Lucene reading side: Simply check if AudioItems were marked as deleted when loading a playlist. Note that this bug doesn't affect the index write side, so after seeing the NPE an ACM will startup again after applying this fix.