### PR TITLE
Handle bulk updates to AudioItemTable more efficiently.

### DIFF
--- a/acm/src/main/java/org/literacybridge/acm/config/ACMConfiguration.java
+++ b/acm/src/main/java/org/literacybridge/acm/config/ACMConfiguration.java
@@ -319,6 +319,11 @@ public class ACMConfiguration {
      * exits.
      */
     private void setupACMGlobalPaths() {
+        File appHomeDir = getApplicationHomeDirectory();
+        if (!appHomeDir.exists()) {
+            appHomeDir.mkdirs();
+        }
+
         boolean dirUpdated = false;
         // If there is an environment override for 'dropbox', use that for the
         // global directory.

--- a/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/audioItems/AudioItemTableModel.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/ResourceView/audioItems/AudioItemTableModel.java
@@ -11,14 +11,22 @@ import org.literacybridge.acm.gui.util.AudioItemNode;
 import org.literacybridge.acm.gui.util.UIUtils;
 import org.literacybridge.acm.gui.util.language.LanguageUtil;
 import org.literacybridge.acm.repository.AudioItemRepository.AudioFormat;
-import org.literacybridge.acm.store.*;
+import org.literacybridge.acm.store.AudioItem;
+import org.literacybridge.acm.store.Committable;
+import org.literacybridge.acm.store.MetadataSpecification;
+import org.literacybridge.acm.store.MetadataStore;
 import org.literacybridge.acm.store.MetadataStore.DataChangeListener;
+import org.literacybridge.acm.store.Playlist;
 import org.literacybridge.acm.utils.B26RotatingEncoding;
 
 import javax.swing.table.AbstractTableModel;
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class AudioItemTableModel extends AbstractTableModel {
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(
@@ -178,11 +186,6 @@ public class AudioItemTableModel extends AbstractTableModel {
                         int row = uuidToRowIndexMap.get(audioItem.getUuid());
 
                         if (eventType == MetadataStore.DataChangeEventType.ITEM_MODIFIED) {
-                            // Unfortunately, we need to do this, even though the callers all
-                            // force a refresh anyway. This causes horrific performance
-                            // from inside Swing; something like O(n^2) on # items selected,
-                            // which kills when setting many items.
-                            //
                             rowIndexToUuidMap.set(row, convertToAudioItemNodeRow(audioItem));
                             fireTableRowsUpdated(row, row);
                         } else if (eventType == MetadataStore.DataChangeEventType.ITEM_DELETED) {

--- a/acm/src/main/java/org/literacybridge/acm/store/Committable.java
+++ b/acm/src/main/java/org/literacybridge/acm/store/Committable.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.literacybridge.acm.store.MetadataStore.DataChangeListener.DataChangeEventType;
+import org.literacybridge.acm.store.MetadataStore.DataChangeEventType;
 
 public abstract class Committable {
   private static enum CommitState {
@@ -114,7 +114,7 @@ public abstract class Committable {
     }
   }
 
-  final void afterCommit(MetadataStore store) {
+  final MetadataStore.DataChangeEvent afterCommit(MetadataStore store) {
     DataChangeEventType dataChangeEventType = DataChangeEventType.ITEM_MODIFIED;
 
     if (deleteState == DeleteState.DELETE_REQUESTED) {
@@ -125,7 +125,7 @@ public abstract class Committable {
       dataChangeEventType = DataChangeEventType.ITEM_ADDED;
     }
 
-    store.fireChangeEvent(this, dataChangeEventType);
+    return new MetadataStore.DataChangeEvent(this, dataChangeEventType);
   }
 
   final void afterRollback() {

--- a/acm/src/main/java/org/literacybridge/acm/store/LuceneMetadataStore.java
+++ b/acm/src/main/java/org/literacybridge/acm/store/LuceneMetadataStore.java
@@ -4,7 +4,11 @@ import com.google.common.collect.Maps;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/acm/src/main/java/org/literacybridge/acm/store/LuceneMetadataStore.java
+++ b/acm/src/main/java/org/literacybridge/acm/store/LuceneMetadataStore.java
@@ -4,11 +4,7 @@ import com.google.common.collect.Maps;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,25 +57,27 @@ public class LuceneMetadataStore extends MetadataStore {
 
     addDataChangeListener(new DataChangeListener() {
       @Override
-      public void dataChanged(Committable item, DataChangeEventType eventType) {
-        if (item instanceof Playlist) {
-          Playlist playlist = (Playlist) item;
-          if (eventType == DataChangeEventType.ITEM_DELETED) {
-            playlistCache.remove(playlist.getUuid());
-          } else {
-            playlistCache.put(playlist.getUuid(), playlist);
+      public void dataChanged(List<DataChangeEvent> events) {
+        for (DataChangeEvent event : events) {
+          Committable item = event.getItem();
+          if (item instanceof Playlist) {
+            Playlist playlist = (Playlist) item;
+            if (event.getEventType() == DataChangeEventType.ITEM_DELETED) {
+              playlistCache.remove(playlist.getUuid());
+            } else {
+              playlistCache.put(playlist.getUuid(), playlist);
+            }
           }
-        }
-        if (item instanceof AudioItem) {
-          AudioItem audioItem = (AudioItem) item;
-          if (eventType == DataChangeEventType.ITEM_DELETED) {
-            audioItemCache.remove(audioItem.getUuid());
-          } else {
-            audioItemCache.put(audioItem.getUuid(), audioItem);
+          if (item instanceof AudioItem) {
+            AudioItem audioItem = (AudioItem) item;
+            if (event.getEventType() == DataChangeEventType.ITEM_DELETED) {
+              audioItemCache.remove(audioItem.getUuid());
+            } else {
+              audioItemCache.put(audioItem.getUuid(), audioItem);
+            }
           }
         }
       }
-
     });
   }
 

--- a/acm/src/main/java/org/literacybridge/acm/store/MetadataStore.java
+++ b/acm/src/main/java/org/literacybridge/acm/store/MetadataStore.java
@@ -5,8 +5,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-import org.literacybridge.acm.store.MetadataStore.DataChangeListener.DataChangeEventType;
-
 import com.google.common.collect.Lists;
 
 public abstract class MetadataStore {
@@ -49,10 +47,9 @@ public abstract class MetadataStore {
     this.dataChangeListeners.add(listener);
   }
 
-  protected final void fireChangeEvent(Committable item,
-      DataChangeEventType eventType) {
+  protected final void fireChangeEvent(List<DataChangeEvent> events) {
     for (DataChangeListener listener : dataChangeListeners) {
-      listener.dataChanged(item, eventType);
+      listener.dataChanged(events);
     }
   }
 
@@ -71,11 +68,29 @@ public abstract class MetadataStore {
     t.commit();
   }
 
-  public interface DataChangeListener {
-    public static enum DataChangeEventType {
-      ITEM_ADDED, ITEM_MODIFIED, ITEM_DELETED
+  public static class DataChangeEvent {
+    private final Committable item;
+    private final DataChangeEventType eventType;
+
+    public DataChangeEvent(Committable item, DataChangeEventType eventType) {
+      this.item = item;
+      this.eventType = eventType;
     }
 
-    public void dataChanged(Committable item, DataChangeEventType eventType);
+    public Committable getItem() {
+      return item;
+    }
+
+    public DataChangeEventType getEventType() {
+      return eventType;
+    }
+  }
+
+  public static enum DataChangeEventType {
+    ITEM_ADDED, ITEM_MODIFIED, ITEM_DELETED
+  }
+
+  public interface DataChangeListener {
+    public void dataChanged(List<DataChangeEvent> events);
   }
 }

--- a/acm/src/main/java/org/literacybridge/acm/store/Transaction.java
+++ b/acm/src/main/java/org/literacybridge/acm/store/Transaction.java
@@ -1,13 +1,12 @@
 package org.literacybridge.acm.store;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.lucene.index.IndexWriter;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-
-import org.apache.lucene.index.IndexWriter;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 public class Transaction {
   private final Set<Committable> objects;
@@ -60,9 +59,11 @@ public class Transaction {
           success2 = true;
         } finally {
           if (success2) {
+            List<MetadataStore.DataChangeEvent> dataChangeEvents = Lists.newArrayListWithCapacity(objects.size());
             for (Committable o : objects) {
-              o.afterCommit(store);
+              dataChangeEvents.add(o.afterCommit(store));
             }
+            store.fireChangeEvent(dataChangeEvents);
             active = false;
           } else {
             rollback();


### PR DESCRIPTION
Changed the way the AudioItemTableModel is notified of updates within a single transaction. Now if one transaction contains multiple changes (e.g. a bulk update of the category of many AudioItems) only a single fireTableDataChanged() is triggered.