### PR TITLE
fix(acm: sync): program content not downloaded if `acm-db/${programId}` directory exists but empty

### DIFF
--- a/acm.code-workspace
+++ b/acm.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../S3Sync"
+		}
+	],
+	"settings": {}
+}

--- a/acm/src/main/java/org/literacybridge/acm/gui/Application.java
+++ b/acm/src/main/java/org/literacybridge/acm/gui/Application.java
@@ -32,10 +32,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.*;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -368,7 +366,7 @@ public class Application extends JXFrame {
 //      System.out.printf("Opening database '%s' in %s\n", sharedACM,
       if (Authenticator.getInstance().isProgramS3(sharedACM)) {
           splashScreen.setProgressLabel("Synchronizing content database...");
-          if (pathsProvider == null) {
+          if (pathsProvider == null || !pathsProvider.getProgramHomeDir().exists() || pathsProvider.getProgramHomeDir().listFiles().length == 0) {
 //              System.out.println("pathsProvider is null");
               // The database doesn't exist locally, but it does exist in S3.
               syncOk = syncFromS3(sharedACM, S3SyncDialog.SYNC_STYLE.DOWNLOAD);

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -10,3 +10,5 @@ cube/
 firmware.v2/
 system.v2/
 OutputDfu/
+7zip
+ffmpeg.7z


### PR DESCRIPTION
This fix downloads the program content if `acm-db/${programId}` directory does not exists or exists but empty

(cherry picked from commit a1fd731d162a37c8cb324a09d5222a00a89ebba2)
